### PR TITLE
Fix bad method call

### DIFF
--- a/lib/ringcaptcha/api.rb
+++ b/lib/ringcaptcha/api.rb
@@ -9,11 +9,11 @@ module Ringcaptcha
   module API
     def self.call(api_key, app_key, path, params = {})
       Instrumentation.instrument(path, params) do
-        call_ringcaptcha(api_key, app_key, path, params = {})
+        call_ringcaptcha(api_key, app_key, path, params)
       end
     end
 
-    def self.call_ringcaptcha(api_key, app_key, path, params = {})
+    def self.call_ringcaptcha(api_key, app_key, path, params)
       uri = URI.parse("https://api.ringcaptcha.com")
       http = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl = true

--- a/lib/ringcaptcha/api_stub.rb
+++ b/lib/ringcaptcha/api_stub.rb
@@ -6,11 +6,11 @@ module Ringcaptcha
   module APIStub
     def self.call(api_key, app_key, path, params = {})
       Instrumentation.instrument(path, params) do
-        call_ringcaptcha(api_key, app_key, path, params = {})
+        call_ringcaptcha(api_key, app_key, path, params)
       end
     end
 
-    def self.call_ringcaptcha(api_key, app_key, path, params = {})
+    def self.call_ringcaptcha(api_key, app_key, path, params)
       root = path.match(/^[^\/]*/).to_s
 
       parsed_json =

--- a/lib/ringcaptcha/version.rb
+++ b/lib/ringcaptcha/version.rb
@@ -1,3 +1,3 @@
 module Ringcaptcha
-  VERSION = "0.3.2"
+  VERSION = "0.3.3"
 end


### PR DESCRIPTION
Currently, we alway call `call_ringcaptcha` with `params = {}`.
I missed that when I tested the previous pull request. (APIStub ignores this param and returns a fixed value...)